### PR TITLE
Update "Upload Python Package" actor

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,6 +6,8 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
+# Editing this file to update actor for this action, see: https://github.com/orgs/community/discussions/25067
+
 name: Upload Python Package
 
 on:


### PR DESCRIPTION
From https://github.com/orgs/community/discussions/25067 : "The latest user who create the schedule trigger will be the actor for the schedule workflow."

This PR adds a comment to the python-publish.yml file to update the actor from `chitalian` to `colin-p-sisu` in the Actions page